### PR TITLE
[문제 해결] 강사 로그인 문제 해결

### DIFF
--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/service/AuthSuccessHandler.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/service/AuthSuccessHandler.java
@@ -45,7 +45,7 @@ public class AuthSuccessHandler implements AuthenticationSuccessHandler {
          * 강사 권한이면 강사 메인페이지 경로로 이동한다.
          */
         if (hasRole(authorities, "ROLE_TEACHER")) {
-            response.sendRedirect("/course/teachermain");
+            response.sendRedirect("/teacher/teachermain");
             return;
         }
 

--- a/src/main/java/com/samsamgyeesam/studyingvally/global/Config/SecurityConfig.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/global/Config/SecurityConfig.java
@@ -51,7 +51,7 @@ public class SecurityConfig {
                                 "/auth/signup1",
                                 "/auth/signup2",
                                 "/auth/signup",
-                                "auth/signuptype",
+                                "/auth/signuptype",
                                 "/auth/find",
                                 "/auth/findid",
                                 "/auth/findid2",
@@ -74,8 +74,8 @@ public class SecurityConfig {
                         .passwordParameter("password")
                         .successHandler(authSuccessHandler)
                         .failureUrl("/auth/login?error=true")
-                )
-                .formLogin(form -> form.disable());
+                );
+//                .formLogin(form -> form.disable());
 
         return http.build();
     }


### PR DESCRIPTION
## [문제 상황]
- 강사로 로그인을 했을 때 403 에러가 뜨면서 페이지로 이동이 안되는 문제 발생

---

## [문제 상황 인지]
1.  AuthSuccessHandler에 로그인 성공 시 강사 메인페이지 이동 경로 불량
 - 기존에 강사 메인체이지 경로는 /course/teachermain으로 설정을 했지만 실제로는 /teacher/teachermain 

2. SecurityConfig에서 .formLogin(form -> form.disable()); 가 존재
- SecurityConfig에서 formLogin 설정 직후 .formLogin(form -> form.disable())가 다시 호출되어, 스프링 시큐리티의 폼 로그인 기능이 비활성화되고 있었습니다.
 - 이로 인해 강사 계정이 /auth/login으로 로그인 요청을 보내도 인증 세션과 성공 리다이렉트가 정상적으로 처리되지 않아 403 error가 뜨는것을 확인

---

## [문제 해결]
- 1번 문제는 경로 재설정으로 문제 해결
-  .formLogin(form -> form.disable());를 주석처리하고 다시 로그인 시도 -> 정상적으로 메인페이지 이동 확인