### PR TITLE
[기능 구현] 모성진 - 회원가입 예외처리, 비밀번호 5회 틀릴 시 계정 잠금

### DIFF
--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/controller/AuthController.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/controller/AuthController.java
@@ -1,5 +1,5 @@
 package com.samsamgyeesam.studyingvally.domain.user.controller;
-// 올리기
+
 import com.samsamgyeesam.studyingvally.domain.user.dto.SignupDTO;
 import com.samsamgyeesam.studyingvally.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
@@ -15,36 +15,49 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/auth")
 public class AuthController {
 
-    // 사용자 비즈니스 로직 서비스
+    /* 사용자 비즈니스 로직 서비스 */
     private final UserService userService;
 
     /**
      * 로그인 화면 반환
      *
-     * 로그인 실패 시 Security에서 /auth/login?error=true 로 보내므로,
-     * error 파라미터가 있으면 화면에 에러 문구를 출력할 수 있도록 model에 담아준다.
+     * 로그인 실패 시 AuthFailHandler에서
+     * /auth/login?error=true&message=... 형태로 보내므로,
+     * error와 message를 받아 화면에 전달한다.
      *
-     * @param error 로그인 실패 여부 파라미터
+     * @param error 로그인 실패 여부
+     * @param message 로그인 실패 메시지
      * @param model View에 전달할 모델 객체
      * @return auth/login
      */
     @GetMapping("/login")
-    public String login(@RequestParam(required = false) String error, Model model) {
+    public String login(@RequestParam(required = false) String error,
+                        @RequestParam(required = false) String message,
+                        Model model) {
 
-        /**
-         * error 파라미터가 존재하면 화면에서 로그인 실패 문구를 보여줄 수 있도록 설정한다.
-         */
+        /* 로그인 실패 여부 전달 */
         if (error != null) {
             model.addAttribute("loginError", true);
+        }
+
+        /* 실패 메시지가 있으면 화면에 전달 */
+        if (message != null && !message.isBlank()) {
+            model.addAttribute("loginErrorMessage", message);
         }
 
         return "auth/login";
     }
 
     /**
+     * 회원가입 유형 선택 화면 반환
+     */
+    @GetMapping("/signup-type")
+    public String signupType() {
+        return "auth/signup-type";
+    }
+
+    /**
      * 회원가입 1단계 화면 반환
-     *
-     * @return auth/signup1
      */
     @GetMapping("/signup1")
     public String signup1(@RequestParam(required = false) String userRole,
@@ -55,10 +68,48 @@ public class AuthController {
         return "auth/signup1";
     }
 
-    /*
-    * 아이디/비밀번호 찾기 반환
-    * 아이디/비밀번호를 잊으셨나요? 버튼을 누르게 되면 아이디/비밀번호 찾기 화면으로 이동
-    * */
+    /**
+     * 회원가입 2단계 화면 이동
+     */
+    @PostMapping("/signup2")
+    public String signup2(@ModelAttribute SignupDTO signupDTO,
+                          Model model) {
+
+        if (signupDTO.getUserName() == null || signupDTO.getUserName().isBlank()
+                || signupDTO.getUserId() == null || signupDTO.getUserId().isBlank()
+                || signupDTO.getUserPassword() == null || signupDTO.getUserPassword().isBlank()
+                || signupDTO.getUserPhoneNumber() == null || signupDTO.getUserPhoneNumber().isBlank()
+                || signupDTO.getUserEmail() == null || signupDTO.getUserEmail().isBlank()) {
+
+            model.addAttribute("signup1Error", "회원가입 정보를 모두 입력해주세요.");
+            model.addAttribute("signupDTO", signupDTO);
+
+            return "auth/signup1";
+        }
+
+        model.addAttribute("signupDTO", signupDTO);
+
+        return "auth/signup2";
+    }
+
+    /**
+     * 회원가입 최종 처리
+     */
+    @PostMapping("/signup")
+    public String signup(@ModelAttribute SignupDTO signupDTO,
+                         Model model) {
+
+        try {
+            userService.signup(signupDTO);
+            return "redirect:/main";
+
+        } catch (IllegalArgumentException exception) {
+            model.addAttribute("signup2Error", exception.getMessage());
+            model.addAttribute("signupDTO", signupDTO);
+            return "auth/signup2";
+        }
+    }
+
     @GetMapping("/find")
     public String find() {
         return "auth/find";
@@ -75,22 +126,12 @@ public class AuthController {
                                Model model) {
 
         try {
-            /**
-             * 실제 서비스 로직을 호출해 아이디를 찾는다.
-             */
             String foundUserId = userService.findUserId(userName, phoneNumber);
-
-            /**
-             * 찾은 아이디를 결과 화면에 전달한다.
-             */
             model.addAttribute("foundUserId", foundUserId);
 
             return "auth/findid2";
 
         } catch (IllegalArgumentException exception) {
-            /**
-             * 실패 시 다시 입력 화면으로 보내고 에러 메시지를 전달한다.
-             */
             model.addAttribute("findIdError", exception.getMessage());
             return "auth/findid";
         }
@@ -109,91 +150,12 @@ public class AuthController {
         try {
             String foundPassword = userService.findUserPassword(userId, phoneNumber);
             model.addAttribute("foundPassword", foundPassword);
+
             return "auth/findpw2";
 
         } catch (IllegalArgumentException exception) {
             model.addAttribute("findPwError", exception.getMessage());
             return "auth/findpw1";
-        }
-    }
-
-    // 회원가입 유형 선택 화면 출력
-    @GetMapping("/signuptype")
-    public String signupType() {
-        return "auth/signuptype";
-    }
-
-
-    /*
-     * 회원가입 2단계 화면 반환
-     *
-     * 회원가입 1단계에서 입력한 값을 받아
-     * 다음 단계 화면으로 전달한다.
-     *
-     * @param userName 사용자 이름
-     * @param userId 사용자 아이디
-     * @param userPassword 사용자 비밀번호
-     * @param userNickname 사용자 닉네임
-     * @param userPhoneNumber 사용자 전화번호
-     * @param userEmail 사용자 이메일
-     * @param model View에 전달할 모델 객체
-     * @return auth/signup2
-     */
-    @PostMapping("/signup2")
-    public String signup2(@ModelAttribute SignupDTO signupDTO,
-                          Model model) {
-
-        /* 1단계 입력값 검증 */
-        if (signupDTO.getUserName() == null || signupDTO.getUserName().isBlank()
-                || signupDTO.getUserId() == null || signupDTO.getUserId().isBlank()
-                || signupDTO.getUserPassword() == null || signupDTO.getUserPassword().isBlank()
-                || signupDTO.getUserPhoneNumber() == null || signupDTO.getUserPhoneNumber().isBlank()
-                || signupDTO.getUserEmail() == null || signupDTO.getUserEmail().isBlank()) {
-
-            /* 에러 메시지 + 기존 입력값 유지 */
-            model.addAttribute("signup1Error", "회원가입 정보를 모두 입력해주세요.");
-            model.addAttribute("signupDTO", signupDTO);
-
-            return "auth/signup1";
-        }
-
-        /* signup2.html에서 signupDTO.userName 처럼 꺼낼 수 있도록 DTO 자체를 넘긴다 */
-        model.addAttribute("signupDTO", signupDTO);
-
-        return "auth/signup2";
-    }
-
-    /**
-     * 회원가입 최종 저장 처리
-     *
-     * signup2.html 에서 전달된 회원가입 정보를 받아
-     * 서비스 계층에서 실제 DB 저장을 수행한다.
-     *
-     * 저장 성공 시 첫 화면(/main)으로 리다이렉트한다.
-     *
-     * @param signupDTO 회원가입 입력값 DTO
-     * @param model View에 전달할 모델 객체
-     * @return 성공 시 redirect:/main, 실패 시 auth/signup2
-     */
-    @PostMapping("/signup")
-    public String signup(@ModelAttribute SignupDTO signupDTO,
-                         Model model) {
-
-        try {
-            /* Service에서 회원가입 처리 */
-            userService.signup(signupDTO);
-
-            /* 성공 시 메인으로 이동 */
-            return "redirect:/main";
-
-        } catch (IllegalArgumentException exception) {
-            /* Service에서 던진 에러 메시지를 화면에 전달 */
-            model.addAttribute("signup2Error", exception.getMessage());
-
-            /* 사용자가 입력한 값 유지 */
-            model.addAttribute("signupDTO", signupDTO);
-
-            return "auth/signup2";
         }
     }
 }

--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/controller/AuthController.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/controller/AuthController.java
@@ -179,29 +179,20 @@ public class AuthController {
     public String signup(@ModelAttribute SignupDTO signupDTO,
                          Model model) {
 
-        System.out.println("=== AuthController.signup 진입 ===");
-        System.out.println("userId = " + signupDTO.getUserId());
-
         try {
+            /* Service에서 회원가입 처리 */
             userService.signup(signupDTO);
 
-            System.out.println("=== 회원가입 성공 후 /main 이동 ===");
+            /* 성공 시 메인으로 이동 */
             return "redirect:/main";
 
         } catch (IllegalArgumentException exception) {
-            System.out.println("=== IllegalArgumentException 발생 ===");
-            exception.printStackTrace();
-
+            /* Service에서 던진 에러 메시지를 화면에 전달 */
             model.addAttribute("signup2Error", exception.getMessage());
-            model.addAttribute("signupDTO", signupDTO);
-            return "auth/signup2";
 
-        } catch (Exception exception) {
-            System.out.println("=== 기타 예외 발생 ===");
-            exception.printStackTrace();
-
-            model.addAttribute("signup2Error", "회원가입 저장 중 오류가 발생했습니다.");
+            /* 사용자가 입력한 값 유지 */
             model.addAttribute("signupDTO", signupDTO);
+
             return "auth/signup2";
         }
     }

--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/controller/StudentInformationController.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/controller/StudentInformationController.java
@@ -113,7 +113,6 @@ public class StudentInformationController {
             model.addAttribute("userInfo", userInfo);
             model.addAttribute("updateDTO", updateDTO);
             model.addAttribute("updateError", exception.getMessage());
-
             model.addAttribute("formActionUrl", "/student/home/update-info");
             model.addAttribute("showPageUrl", "/student/home/info");
 

--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/controller/TeacherInformationController.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/controller/TeacherInformationController.java
@@ -121,7 +121,6 @@ public class TeacherInformationController {
 
             userService.updateUserInformation(loginUserId, updateDTO);
 
-            /* 수정 완료 후 다시 조회 화면으로 이동 */
             return "redirect:/showinformation";
 
         } catch (IllegalArgumentException exception) {
@@ -132,15 +131,12 @@ public class TeacherInformationController {
             model.addAttribute("userInfo", userInfo);
             model.addAttribute("updateDTO", updateDTO);
             model.addAttribute("updateError", exception.getMessage());
-
             model.addAttribute("formActionUrl", "/updateinformation");
             model.addAttribute("showPageUrl", "/showinformation");
-
 
             return "auth/updateinformation";
         }
     }
-
     /**
      * 강사 탈퇴 화면 이동
      *

--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/entity/LoginLog.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/entity/LoginLog.java
@@ -1,0 +1,39 @@
+package com.samsamgyeesam.studyingvally.domain.user.entity;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDateTime;
+
+/**
+ * 로그인 성공/실패 로그를 저장하는 엔티티
+ */
+@Entity
+@Table(name = "login_log")
+public class LoginLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private String userId;
+
+    @Column(name = "login_time", nullable = false)
+    private LocalDateTime loginTime;
+
+    @Column(name = "success", nullable = false)
+    private boolean success;
+
+    @Column(name = "ip_address")
+    private String ipAddress;
+
+    public LoginLog() {
+    }
+
+    public LoginLog(String userId, LocalDateTime loginTime, boolean success, String ipAddress) {
+        this.userId = userId;
+        this.loginTime = loginTime;
+        this.success = success;
+        this.ipAddress = ipAddress;
+    }
+}

--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/entity/UserUser.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/entity/UserUser.java
@@ -1,28 +1,18 @@
 package com.samsamgyeesam.studyingvally.domain.user.entity;
 
-import com.samsamgyeesam.studyingvally.baseentity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 
 /**
- * user 테이블과 매핑되는 엔티티이다.
- *
- * 현재 로그인에서 핵심적으로 사용하는 컬럼:
- * - user_id
- * - user_password
- * - user_role
- *
- * 그 외 컬럼도 이후 마이페이지, 회원정보 조회 등에 사용할 수 있으므로 함께 매핑한다.
+ * user 테이블과 매핑되는 엔티티
  */
 @Getter
 @Entity
 @Table(name = "user")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class UserUser extends BaseTimeEntity {
+public class UserUser {
 
     /**
      * 사용자 PK
@@ -41,7 +31,8 @@ public class UserUser extends BaseTimeEntity {
     /**
      * 비밀번호
      *
-     * 현재는 평문 상태를 그대로 사용한다.
+     * 현재는 평문 상태 그대로 사용
+     * 나중에 BCrypt로 변경 예정
      */
     @Column(name = "user_password", nullable = false)
     private String userPassword;
@@ -49,13 +40,13 @@ public class UserUser extends BaseTimeEntity {
     /**
      * 전화번호
      */
-    @Column(name = "user_phone_number", unique = true)
+    @Column(name = "user_phone_number")
     private String userPhoneNumber;
 
     /**
      * 이메일
      */
-    @Column(name = "user_email", unique = true)
+    @Column(name = "user_email")
     private String userEmail;
 
     /**
@@ -68,7 +59,7 @@ public class UserUser extends BaseTimeEntity {
     /**
      * 닉네임
      */
-    @Column(name = "user_nickname", unique = true)
+    @Column(name = "user_nickname")
     private String userNickname;
 
     /**
@@ -77,14 +68,35 @@ public class UserUser extends BaseTimeEntity {
     @Column(name = "user_name", nullable = false)
     private String userName;
 
-    /* 상태 */
+    /**
+     * 사용자 상태
+     *
+     * 예: ACTIVE
+     */
     @Column(name = "user_status", nullable = false)
     private String userStatus;
 
-    /* 성별 */
+    /**
+     * 성별
+     */
     @Column(name = "user_gender", nullable = false)
     private String userGender;
 
+    /**
+     * 로그인 실패 횟수
+     */
+    @Column(name = "login_fail_count", nullable = false)
+    private int loginFailCount;
+
+    /**
+     * 계정 잠금 여부
+     */
+    @Column(name = "is_account_locked", nullable = false)
+    private boolean accountLocked;
+
+    /**
+     * 기존 프로젝트 스타일에 맞춘 builder 시작 메서드
+     */
     public static UserUser builder() {
         return new UserUser();
     }
@@ -134,8 +146,21 @@ public class UserUser extends BaseTimeEntity {
         return this;
     }
 
-    /*
-     * 학생 / 강사 공통 정보 수정 메서드
+    public UserUser loginFailCount(int loginFailCount) {
+        this.loginFailCount = loginFailCount;
+        return this;
+    }
+
+    public UserUser accountLocked(boolean accountLocked) {
+        this.accountLocked = accountLocked;
+        return this;
+    }
+
+    /**
+     * 내 정보 수정
+     *
+     * 이름은 수정하지 않고
+     * 전화번호, 이메일, 비밀번호만 수정
      */
     public void updateInformation(String userPhoneNumber, String userEmail, String userPassword) {
         this.userPhoneNumber = userPhoneNumber;
@@ -143,4 +168,24 @@ public class UserUser extends BaseTimeEntity {
         this.userPassword = userPassword;
     }
 
+    /**
+     * 로그인 실패 횟수 증가
+     */
+    public void increaseLoginFailCount() {
+        this.loginFailCount++;
+    }
+
+    /**
+     * 로그인 실패 횟수 초기화
+     */
+    public void resetLoginFailCount() {
+        this.loginFailCount = 0;
+    }
+
+    /**
+     * 계정 잠금 처리
+     */
+    public void lockAccount() {
+        this.accountLocked = true;
+    }
 }

--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/repository/LoginLogRepository.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/repository/LoginLogRepository.java
@@ -1,0 +1,7 @@
+package com.samsamgyeesam.studyingvally.domain.user.repository;
+
+import com.samsamgyeesam.studyingvally.domain.user.entity.LoginLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LoginLogRepository extends JpaRepository<LoginLog, Long> {
+}

--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/service/AuthFailHandler.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/service/AuthFailHandler.java
@@ -1,0 +1,103 @@
+package com.samsamgyeesam.studyingvally.domain.user.service;
+
+import com.samsamgyeesam.studyingvally.domain.user.entity.LoginLog;
+import com.samsamgyeesam.studyingvally.domain.user.repository.LoginLogRepository;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.LockedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+
+/**
+ * 로그인 실패 시 처리하는 핸들러
+ *
+ * 처리 내용:
+ * 1. 비밀번호가 틀렸을 경우 로그인 실패 횟수 증가
+ * 2. 계정 잠김 상태일 경우 잠김 메시지 반환
+ * 3. 로그인 실패 로그 저장
+ * 4. 로그인 화면으로 다시 이동
+ */
+@Component
+@RequiredArgsConstructor
+public class AuthFailHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    /* 사용자 관련 서비스 */
+    private final UserService userService;
+
+    /* 로그인 성공/실패 로그 저장용 Repository */
+    private final LoginLogRepository loginLogRepository;
+
+    /**
+     * 로그인 실패 시 실행되는 메서드
+     *
+     * @param request 로그인 요청 객체
+     * @param response 응답 객체
+     * @param exception 인증 실패 예외
+     */
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException, ServletException {
+
+        /* 로그인 폼에서 입력한 아이디 */
+        String loginId = request.getParameter("loginId");
+
+        /* 접속 IP 주소 */
+        String ipAddress = request.getRemoteAddr();
+
+        /* 화면에 보여줄 에러 메시지 */
+        String errorMessage;
+
+        /*
+         * 비밀번호 불일치 또는 아이디 없음
+         * -> 실패 횟수 증가
+         */
+        if (exception instanceof BadCredentialsException) {
+            errorMessage = "아이디가 존재하지 않거나 비밀번호가 일치하지 않습니다.";
+
+            if (loginId != null && !loginId.isBlank()) {
+                userService.incrementLoginFailCount(loginId);
+            }
+
+            /*
+             * 계정 잠금 상태
+             * -> 잠금 메시지 반환
+             */
+        } else if (exception instanceof LockedException) {
+            errorMessage = "로그인 5회 실패로 계정이 잠겼습니다. 관리자에게 문의하세요.";
+
+            /*
+             * 그 외 예외
+             */
+        } else {
+            errorMessage = "로그인 요청을 처리할 수 없습니다.";
+        }
+
+        /* 로그인 실패 로그 저장 */
+        loginLogRepository.save(
+                new LoginLog(
+                        loginId,              // 로그인 시도 아이디
+                        LocalDateTime.now(),  // 로그인 시각
+                        false,                // 로그인 성공 여부
+                        ipAddress             // 접속 IP
+                )
+        );
+
+        /* 한글 메시지 URL 인코딩 */
+        errorMessage = URLEncoder.encode(errorMessage, StandardCharsets.UTF_8);
+
+        /* 로그인 페이지로 다시 이동 */
+        setDefaultFailureUrl("/auth/login?error=true&message=" + errorMessage);
+
+        super.onAuthenticationFailure(request, response, exception);
+    }
+}

--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/service/AuthSuccessHandler.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/service/AuthSuccessHandler.java
@@ -1,82 +1,100 @@
 package com.samsamgyeesam.studyingvally.domain.user.service;
 
+import com.samsamgyeesam.studyingvally.domain.user.entity.LoginLog;
+import com.samsamgyeesam.studyingvally.domain.user.repository.LoginLogRepository;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
+import java.time.LocalDateTime;
 import java.util.Collection;
 
-/*
- * 로그인 성공 후 권한별 이동 경로를 분기하는 핸들러이다.
+/**
+ * 로그인 성공 후 처리 핸들러
  *
- * 현재 팀 프로젝트 기준 경로:
- * - 강사 : /course/teachermain
- * - 학생 : /student/main
- * - 관리자 : admin/main
+ * 처리 내용:
+ * 1. 로그인 성공 시 로그인 실패 횟수 초기화
+ * 2. 로그인 성공 로그 저장
+ * 3. 사용자 권한에 따라 메인 화면 분기
  */
 @Component
+@RequiredArgsConstructor
 public class AuthSuccessHandler implements AuthenticationSuccessHandler {
 
+    /* 사용자 관련 서비스 */
+    private final UserService userService;
+
+    /* 로그인 성공/실패 로그 저장용 Repository */
+    private final LoginLogRepository loginLogRepository;
+
     /**
-     * 로그인 성공 시 권한을 확인한 뒤 각 경로로 이동시킨다.
+     * 로그인 성공 시 실행되는 메서드
      *
-     * @param request 요청 객체
+     * @param request 로그인 요청 객체
      * @param response 응답 객체
-     * @param authentication 인증 객체
-     * @throws IOException 입출력 예외
-     * @throws ServletException 서블릿 예외
+     * @param authentication 인증 완료된 사용자 정보
      */
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request,
                                         HttpServletResponse response,
                                         Authentication authentication) throws IOException, ServletException {
 
-        /*
-         * 현재 로그인한 사용자의 권한 목록을 가져온다.
-         */
+        /* 현재 로그인한 사용자 아이디 */
+        String loginId = authentication.getName();
+
+        /* 현재 접속 IP 주소 */
+        String ipAddress = request.getRemoteAddr();
+
+        /* 로그인 성공 시 실패 횟수 초기화 */
+        userService.resetLoginFailCount(loginId);
+
+        /* 로그인 성공 로그 저장 */
+        loginLogRepository.save(
+                new LoginLog(
+                        loginId,              // 로그인한 사용자 아이디
+                        LocalDateTime.now(),  // 로그인 시각
+                        true,                 // 로그인 성공 여부
+                        ipAddress             // 접속 IP
+                )
+        );
+
+        /* 현재 로그인한 사용자의 권한 목록 */
         Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
 
-        /*
-         * 강사 권한이면 강사 메인페이지 경로로 이동한다.
-         */
+        /* 강사 권한이면 강사 메인으로 이동 */
         if (hasRole(authorities, "ROLE_TEACHER")) {
-            response.sendRedirect("/teacher/teachermain");
+            response.sendRedirect("/course/teachermain");
             return;
         }
 
-        /*
-         * 학생 권한이면 학생 메인페이지 경로로 이동한다.
-         */
+        /* 학생 권한이면 학생 메인으로 이동 */
         if (hasRole(authorities, "ROLE_STUDENT")) {
             response.sendRedirect("/student/main");
             return;
         }
 
-        /*
-         * 관리자 권한이면 아직 관리자 메인페이지가 없으므로 공용 /main 으로 이동한다.
-         */
+        /* 관리자 권한이면 관리자 메인으로 이동 */
         if (hasRole(authorities, "ROLE_ADMIN")) {
             response.sendRedirect("/admin/main");
             return;
         }
 
-        /*
-         * 혹시 어떤 권한에도 해당하지 않으면 기본적으로 /main 으로 이동한다.
-         */
+        /* 그 외는 공통 메인으로 이동 */
         response.sendRedirect("/main");
     }
 
-    /*
-     * 권한 목록 안에 특정 권한이 있는지 확인한다.
+    /**
+     * 현재 권한 목록에 특정 권한이 포함되어 있는지 확인하는 메서드
      *
-     * @param authorities 현재 로그인한 사용자의 권한 목록
+     * @param authorities 현재 로그인 사용자의 권한 목록
      * @param role 확인할 권한 문자열
-     * @return 권한 포함 여부
+     * @return 포함 여부
      */
     private boolean hasRole(Collection<? extends GrantedAuthority> authorities, String role) {
         return authorities.stream()

--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/service/AuthUserDetails.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/service/AuthUserDetails.java
@@ -11,11 +11,9 @@ import java.util.Collection;
 import java.util.List;
 
 /**
- * Spring Security 세션에 저장될 인증 사용자 객체이다.
- *
- * 현재는 User와 Admin을 모두 처리할 수 있도록 확장한다.
+ * Spring Security 세션에 저장될 사용자 정보 객체
  */
-
+@Getter
 public class AuthUserDetails implements UserDetails {
 
     /**
@@ -30,20 +28,28 @@ public class AuthUserDetails implements UserDetails {
 
     /**
      * 권한 문자열
+     *
+     * 예: ROLE_STUDENT, ROLE_TEACHER, ROLE_ADMIN
      */
     private final String role;
 
     /**
-     * 화면 표시용 이름
+     * 화면에 표시할 이름
      */
     private final String displayName;
 
-    private Long userNo;
+    /**
+     * 일반 사용자 PK
+     */
+    private final Long userNo;
 
     /**
-     * 일반 사용자(User) 기반 생성자
-     *
-     * @param user 일반 사용자 엔티티
+     * 계정 잠금 여부
+     */
+    private final boolean accountLocked;
+
+    /**
+     * 일반 사용자 생성자
      */
     public AuthUserDetails(UserUser user) {
         this.loginId = user.getUserId();
@@ -51,36 +57,23 @@ public class AuthUserDetails implements UserDetails {
         this.role = "ROLE_" + user.getUserRole().name();
         this.displayName = user.getUserNickname();
         this.userNo = user.getUserNo();
+        this.accountLocked = user.isAccountLocked();
     }
 
     /**
-     * 관리자(Admin) 기반 생성자
-     *
-     * admin 테이블에는 role 컬럼이 없으므로
-     * Security 내부에서는 ROLE_ADMIN으로 고정한다.
-     *
-     * @param admin 관리자 엔티티
+     * 관리자 생성자
      */
     public AuthUserDetails(UserAdmin admin) {
         this.loginId = admin.getAdminId();
         this.password = admin.getAdminPassword();
         this.role = "ROLE_ADMIN";
         this.displayName = "관리자";
+        this.userNo = null;
+        this.accountLocked = false;
     }
 
     /**
-     * 화면에서 현재 로그인한 사용자명을 표시할 때 사용할 수 있다.
-     *
-     * @return 표시용 이름
-     */
-    public String getDisplayName() {
-        return displayName;
-    }
-
-    /**
-     * 현재 사용자의 권한 목록을 반환한다.
-     *
-     * @return 권한 컬렉션
+     * 현재 사용자의 권한 목록 반환
      */
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
@@ -88,23 +81,17 @@ public class AuthUserDetails implements UserDetails {
     }
 
     /**
-     * 비밀번호 반환
-     *
-     * @return 비밀번호
+     * Security가 사용할 비밀번호 반환
      */
     @Override
     public String getPassword() {
         return password;
     }
 
-    public Long getUserNo() {
-        return userNo;
-    }
-
     /**
-     * 로그인 아이디 반환
+     * Security가 사용할 username 반환
      *
-     * @return 로그인 아이디
+     * 현재 프로젝트에서는 loginId를 username처럼 사용
      */
     @Override
     public String getUsername() {
@@ -113,10 +100,6 @@ public class AuthUserDetails implements UserDetails {
 
     /**
      * 계정 만료 여부
-     *
-     * 현재는 별도 관리하지 않으므로 true
-     *
-     * @return true
      */
     @Override
     public boolean isAccountNonExpired() {
@@ -126,21 +109,15 @@ public class AuthUserDetails implements UserDetails {
     /**
      * 계정 잠금 여부
      *
-     * 현재는 별도 관리하지 않으므로 true
-     *
-     * @return true
+     * false면 Spring Security가 로그인 차단
      */
     @Override
     public boolean isAccountNonLocked() {
-        return true;
+        return !accountLocked;
     }
 
     /**
      * 비밀번호 만료 여부
-     *
-     * 현재는 별도 관리하지 않으므로 true
-     *
-     * @return true
      */
     @Override
     public boolean isCredentialsNonExpired() {
@@ -149,10 +126,6 @@ public class AuthUserDetails implements UserDetails {
 
     /**
      * 계정 활성 여부
-     *
-     * 현재는 별도 관리하지 않으므로 true
-     *
-     * @return true
      */
     @Override
     public boolean isEnabled() {

--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/service/UserService.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/service/UserService.java
@@ -11,54 +11,58 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-// 사용자 관련 비즈니스 로직을 담당하는 서비스이다.
+/**
+ * 사용자 관련 비즈니스 로직 서비스
+ */
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class UserService {
 
-    // user 테이블 조회용 Repository
+    /**
+     * user 테이블 조회용 Repository
+     */
     private final UserRepository userRepository;
 
-    // 이메일 형식 메서드
-    private boolean isValidEmailFormat(String email) {
-        return email != null
-                && email.matches("^[A-Za-z0-9]+@gmail\\.com$");
-    }
-
-    // 이름과 전화번호를 사용해 아이디 찾기
+    /**
+     * 이름 + 전화번호로 아이디 찾기
+     */
     public String findUserId(String userName, String phoneNumber) {
 
-        // 이름 또는 전화번호가 비어 있는 경우 예외 처리
-        if (userName == null || userName.isBlank() || phoneNumber == null || phoneNumber.isBlank()) {
+        if (userName == null || userName.isBlank()
+                || phoneNumber == null || phoneNumber.isBlank()) {
             throw new IllegalArgumentException("회원가입 정보를 모두 입력해주세요");
         }
 
-        // 이름 + 전화번호가 일치하는 사용자를 조회한다.
         UserUser foundUser = userRepository.findByUserNameAndUserPhoneNumber(userName, phoneNumber)
                 .orElseThrow(() -> new IllegalArgumentException("일치하는 회원 정보를 찾을 수 없습니다."));
 
-        // 조회된 사용자의 아이디를 반환한다.
         return foundUser.getUserId();
     }
 
+    /**
+     * 아이디 + 전화번호로 비밀번호 찾기
+     */
     public String findUserPassword(String userId, String phoneNumber) {
 
-        if (userId == null || userId.isBlank() || phoneNumber == null || phoneNumber.isBlank()) {
+        if (userId == null || userId.isBlank()
+                || phoneNumber == null || phoneNumber.isBlank()) {
             throw new IllegalArgumentException("회원가입 정보를 모두 입력해주세요");
         }
 
-        UserUser user = userRepository
-                .findByUserIdAndUserPhoneNumber(userId, phoneNumber)
+        UserUser user = userRepository.findByUserIdAndUserPhoneNumber(userId, phoneNumber)
                 .orElseThrow(() -> new IllegalArgumentException("일치하는 회원 정보를 찾을 수 없습니다."));
 
         return user.getUserPassword();
     }
 
+    /**
+     * 회원가입
+     */
     @Transactional
     public void signup(SignupDTO signupDTO) {
 
-        // 필수값 검증
+        /* 필수값 검증 */
         if (signupDTO.getUserName() == null || signupDTO.getUserName().isBlank()
                 || signupDTO.getUserId() == null || signupDTO.getUserId().isBlank()
                 || signupDTO.getUserPassword() == null || signupDTO.getUserPassword().isBlank()
@@ -70,31 +74,39 @@ public class UserService {
             throw new IllegalArgumentException("회원가입 정보를 모두 입력해주세요.");
         }
 
-        // 이메일 형식 검증 추가
+        /* 이메일 형식 검증
+         * 조건:
+         * - gmail.com만 허용
+         * - @ 앞은 영문/숫자만 허용
+         */
         if (!isValidEmailFormat(signupDTO.getUserEmail())) {
             throw new IllegalArgumentException("gmail 형식의 이메일만 입력 가능합니다.");
         }
 
-        // 아이디 중복 검사
+        /* 아이디 중복 검사 */
         if (userRepository.existsByUserId(signupDTO.getUserId())) {
             throw new IllegalArgumentException("이미 사용 중인 아이디입니다.");
         }
 
-        // 이메일 중복 검사
+        /* 이메일 중복 검사 */
         if (userRepository.existsByUserEmail(signupDTO.getUserEmail())) {
             throw new IllegalArgumentException("이미 사용 중인 이메일입니다.");
         }
 
-        // 전화번호 중복 검사
+        /* 전화번호 중복 검사 */
         if (userRepository.existsByUserPhoneNumber(signupDTO.getUserPhoneNumber())) {
             throw new IllegalArgumentException("이미 사용 중인 전화번호입니다.");
         }
 
-        // 닉네임 중복 검사
+        /* 닉네임 중복 검사 */
         if (userRepository.existsByUserNickname(signupDTO.getUserNickname())) {
             throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
         }
 
+        /*
+         * 회원가입 시작 화면에서 선택한 역할값을
+         * String -> Enum 으로 변환
+         */
         UserRole selectedRole;
 
         if ("STUDENT".equals(signupDTO.getUserRole())) {
@@ -105,6 +117,7 @@ public class UserService {
             throw new IllegalArgumentException("회원가입 유형을 선택해주세요.");
         }
 
+        /* DTO -> Entity 변환 */
         UserUser newUser = UserUser.builder()
                 .userName(signupDTO.getUserName())
                 .userId(signupDTO.getUserId())
@@ -114,12 +127,16 @@ public class UserService {
                 .userNickname(signupDTO.getUserNickname())
                 .userGender(signupDTO.getUserGender())
                 .userRole(selectedRole)
-                .userStatus("ACTIVE");
+                .userStatus("ACTIVE")
+                .loginFailCount(0)
+                .accountLocked(false);
 
         userRepository.save(newUser);
     }
 
-    // 현재 로그인한 사용자 정보 조회
+    /**
+     * 현재 로그인한 사용자 정보 조회
+     */
     public UserInformationResponseDTO getUserInformation(String loginUserId) {
 
         UserUser user = userRepository.findByUserId(loginUserId)
@@ -133,7 +150,9 @@ public class UserService {
         );
     }
 
-    // 현재 로그인한 사용자 정보 수정
+    /**
+     * 현재 로그인한 사용자 정보 수정
+     */
     @Transactional
     public void updateUserInformation(String loginUserId, UserInformationUpdateDTO updateDTO) {
 
@@ -146,61 +165,107 @@ public class UserService {
             throw new IllegalArgumentException("수정할 정보를 모두 입력해주세요.");
         }
 
-        // 이메일 형식 검증 추가
+        /* 이메일 형식 검증 */
         if (!isValidEmailFormat(updateDTO.getUserEmail())) {
             throw new IllegalArgumentException("gmail 형식의 이메일만 입력 가능합니다.");
         }
+
         user.updateInformation(
                 updateDTO.getUserPhoneNumber(),
                 updateDTO.getUserEmail(),
                 updateDTO.getUserPassword()
         );
     }
+
     /**
-     * 현재 로그인한 사용자의 계정을 삭제한다.
-     * 탈퇴 전 입력한 비밀번호와
-     * 현재 로그인한 사용자 비밀번호가 일치해야 탈퇴 가능하다.
+     * 회원 탈퇴
      */
     @Transactional
     public void deleteAccount(String loginUserId, DeleteUserDTO deleteUserDTO) {
 
-        /* 현재 로그인한 사용자 조회 */
         UserUser user = userRepository.findByUserId(loginUserId)
                 .orElseThrow(() -> new IllegalArgumentException("회원 정보를 찾을 수 없습니다."));
 
-        /* 입력 비밀번호 검증 */
         if (deleteUserDTO.getUserPassword() == null || deleteUserDTO.getUserPassword().isBlank()) {
             throw new IllegalArgumentException("비밀번호를 입력해주세요.");
         }
 
-        /* 현재 프로젝트는 평문 비교 방식 기준 */
         if (!user.getUserPassword().equals(deleteUserDTO.getUserPassword())) {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
 
-        /* 사용자 삭제 */
         userRepository.delete(user);
     }
 
-    /*
-     * 현재 로그인한 사용자의 비밀번호를 확인한다.
-     * 내 정보 조회/수정 진입 전에
-     * 비밀번호 재확인을 위한 메서드이다.
+    /**
+     * 내 정보 조회/수정 전 비밀번호 확인
      */
     public void verifyUserPassword(String loginUserId, String userPassword) {
 
-        /* 현재 로그인한 사용자 조회 */
         UserUser user = userRepository.findByUserId(loginUserId)
                 .orElseThrow(() -> new IllegalArgumentException("회원 정보를 찾을 수 없습니다."));
 
-        /* 비밀번호 입력 여부 확인 */
         if (userPassword == null || userPassword.isBlank()) {
             throw new IllegalArgumentException("비밀번호를 입력해주세요.");
         }
 
-        // DB에 저장 된 비밀번호와 매칭 후 틀리면 문구 띄우기
         if (!user.getUserPassword().equals(userPassword)) {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
+    }
+
+    /**
+     * 로그인 실패 횟수 증가
+     *
+     * 5회 이상이면 계정 잠금
+     */
+    @Transactional
+    public void incrementLoginFailCount(String loginId) {
+
+        UserUser user = userRepository.findByUserId(loginId).orElse(null);
+
+        /* 존재하지 않는 아이디면 종료 */
+        if (user == null) {
+            return;
+        }
+
+        /* 이미 잠긴 계정이면 종료 */
+        if (user.isAccountLocked()) {
+            return;
+        }
+
+        user.increaseLoginFailCount();
+
+        if (user.getLoginFailCount() >= 5) {
+            user.lockAccount();
+        }
+    }
+
+    /**
+     * 로그인 성공 시 실패 횟수 초기화
+     */
+    @Transactional
+    public void resetLoginFailCount(String loginId) {
+
+        UserUser user = userRepository.findByUserId(loginId).orElse(null);
+
+        if (user == null) {
+            return;
+        }
+
+        user.resetLoginFailCount();
+    }
+
+    /*
+     * 이메일 형식 검증 메서드
+     *
+     * 조건:
+     * - gmail.com만 허용
+     * - @ 앞은 영문 대소문자와 숫자만 허용
+     * - . _ - 같은 특수문자는 허용하지 않음
+     */
+    private boolean isValidEmailFormat(String email) {
+        return email != null
+                && email.matches("^[A-Za-z0-9]+@gmail\\.com$");
     }
 }

--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/service/UserService.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/service/UserService.java
@@ -20,6 +20,12 @@ public class UserService {
     // user 테이블 조회용 Repository
     private final UserRepository userRepository;
 
+    // 이메일 형식 메서드
+    private boolean isValidEmailFormat(String email) {
+        return email != null
+                && email.matches("^[A-Za-z0-9]+@gmail\\.com$");
+    }
+
     // 이름과 전화번호를 사용해 아이디 찾기
     public String findUserId(String userName, String phoneNumber) {
 
@@ -64,6 +70,11 @@ public class UserService {
             throw new IllegalArgumentException("회원가입 정보를 모두 입력해주세요.");
         }
 
+        // 이메일 형식 검증 추가
+        if (!isValidEmailFormat(signupDTO.getUserEmail())) {
+            throw new IllegalArgumentException("gmail 형식의 이메일만 입력 가능합니다.");
+        }
+
         // 아이디 중복 검사
         if (userRepository.existsByUserId(signupDTO.getUserId())) {
             throw new IllegalArgumentException("이미 사용 중인 아이디입니다.");
@@ -84,10 +95,6 @@ public class UserService {
             throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
         }
 
-        /*
-         * 회원가입 시작 화면에서 선택한 역할값을
-         * String -> Enum 으로 변환한다.
-         */
         UserRole selectedRole;
 
         if ("STUDENT".equals(signupDTO.getUserRole())) {
@@ -98,7 +105,6 @@ public class UserService {
             throw new IllegalArgumentException("회원가입 유형을 선택해주세요.");
         }
 
-        /* DTO -> Entity 변환 */
         UserUser newUser = UserUser.builder()
                 .userName(signupDTO.getUserName())
                 .userId(signupDTO.getUserId())
@@ -140,6 +146,10 @@ public class UserService {
             throw new IllegalArgumentException("수정할 정보를 모두 입력해주세요.");
         }
 
+        // 이메일 형식 검증 추가
+        if (!isValidEmailFormat(updateDTO.getUserEmail())) {
+            throw new IllegalArgumentException("gmail 형식의 이메일만 입력 가능합니다.");
+        }
         user.updateInformation(
                 updateDTO.getUserPhoneNumber(),
                 updateDTO.getUserEmail(),

--- a/src/main/java/com/samsamgyeesam/studyingvally/global/Config/SecurityConfig.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/global/Config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.samsamgyeesam.studyingvally.global.Config;
 
+import com.samsamgyeesam.studyingvally.domain.user.service.AuthFailHandler;
 import com.samsamgyeesam.studyingvally.domain.user.service.AuthSuccessHandler;
 import com.samsamgyeesam.studyingvally.domain.user.service.AuthUserDetailsService;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,8 @@ public class SecurityConfig {
 
     //로그인 성공 후 권한별 이동 경로를 분기하는 핸들러
     private final AuthSuccessHandler authSuccessHandler;
+
+    private final AuthFailHandler authFailHandler;
 
     // 정적 리소스 예외 처리 (js, css, images 등)
     @Bean
@@ -61,19 +64,31 @@ public class SecurityConfig {
                 )
 
 
-                // 로그인 설정
+                /*
+                 * 로그인 설정
+                 */
                 .formLogin(login -> login
-                                .loginPage("/auth/login")
-                                .loginProcessingUrl("/auth/login")
-                                .usernameParameter("loginId")
-                                .passwordParameter("password")
-                                .successHandler(authSuccessHandler)
-                                .failureUrl("/auth/login?error=true")
+                        .loginPage("/auth/login")
+                        .loginProcessingUrl("/auth/login")
+                        .usernameParameter("loginId")
+                        .passwordParameter("password")
+                        .successHandler(authSuccessHandler)
+                        .failureHandler(authFailHandler)
+                        .permitAll()
                 )
 
-                .logout( logout -> logout
+                /*
+                 * 로그아웃 설정
+                 */
+                .logout(logout -> logout
+                        .logoutUrl("/auth/logout")
                         .logoutSuccessUrl("/main")
+                        .invalidateHttpSession(true)
+                        .clearAuthentication(true)
+                        .permitAll()
                 );
+
+
         // 히히
 
         return http.build();

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -10,11 +10,12 @@
   <!-- 브라우저 탭 제목 -->
   <title>강의 마을 - 로그인</title>
 
-  <!-- CSS 연결 -->
+  <!-- auth 화면 공통 CSS -->
   <link rel="stylesheet" th:href="@{/css/auth.css}">
 </head>
 <body>
 <div class="game-screen">
+  <!-- 배경 요소 -->
   <div class="sun"></div>
   <div class="cloud c1"></div>
   <div class="cloud c2"></div>
@@ -42,12 +43,12 @@
       <section id="loginScreen" class="form-screen active">
         <h1 class="title">로그인</h1>
 
-        <!--
-          실제 로그인 요청을 서버로 보내는 form이다.
-          action과 name 값은 SecurityConfig와 반드시 맞아야 한다.
-        -->
+        <!-- 로그인 처리 form
+             POST /auth/login 은 Controller가 직접 처리하는 것이 아니라
+             Spring Security가 가로채서 인증을 진행한다. -->
         <form class="form-box" th:action="@{/auth/login}" method="post">
 
+          <!-- 로그인 아이디 -->
           <div class="field">
             <label for="loginId">아이디</label>
             <input type="text"
@@ -57,6 +58,7 @@
                    required />
           </div>
 
+          <!-- 로그인 비밀번호 -->
           <div class="field">
             <label for="password">비밀번호</label>
             <input type="password"
@@ -66,8 +68,9 @@
                    required />
           </div>
 
+          <!-- 버튼 영역 -->
           <div class="bottom-row">
-            <!-- 뒤로가기는 submit이 아니라 단순 이동 -->
+            <!-- 메인 화면으로 이동 -->
             <button type="button"
                     onclick="location.href='/main'"
                     class="pixel-btn secondary"
@@ -75,7 +78,7 @@
               뒤로가기
             </button>
 
-            <!-- 실제 로그인 제출 -->
+            <!-- 로그인 요청 -->
             <button type="submit"
                     class="pixel-btn"
                     id="loginSubmitBtn">
@@ -83,11 +86,23 @@
             </button>
           </div>
 
-          <!-- 로그인 실패 시 메시지 -->
-          <div id="loginMsg" class="msg show error" th:if="${loginError}">
-            아이디 또는 비밀번호를 확인해주세요.
+          <!-- 로그인 실패 메시지 출력
+               AuthFailHandler -> /auth/login?error=true&message=...
+               AuthController.login() -> model에 loginErrorMessage 전달 -->
+          <div id="loginMsg"
+               class="msg show error"
+               th:if="${loginErrorMessage != null}">
+                        <span th:text="${loginErrorMessage}">
+                            아이디 또는 비밀번호를 확인해주세요.
+                        </span>
           </div>
+
         </form>
+
+        <!-- 아이디 / 비밀번호 찾기 -->
+        <div class="helper-links">
+          <a th:href="@{/auth/find}">아이디 / 비밀번호를 잊으셨나요?</a>
+        </div>
       </section>
 
     </div>

--- a/src/main/resources/templates/auth/signup1.html
+++ b/src/main/resources/templates/auth/signup1.html
@@ -91,7 +91,7 @@
                     <!-- 0~9까지 4자리만 쓰겠다는 것-->
                     <div class="field">
                         <label for="userPhoneNumber">전화번호</label>
-                        <input type="text"
+                        <input type="tel"
                                id="userPhoneNumber"
                                name="userPhoneNumber"
                                placeholder="전화번호 입력 ex)010-1234-1234"

--- a/src/main/resources/templates/auth/signup2.html
+++ b/src/main/resources/templates/auth/signup2.html
@@ -185,9 +185,10 @@
                     </div>
 
                     <!-- signup2 단계 에러 메시지 -->
-                    <div class="msg show error"
-                         th:if="${signup2Error}">
-                        <span th:text="${signup2Error}">회원가입 에러 메시지</span>
+                    <div th:if="${signup2Error != null}"
+                         class="error-message"
+                         th:text="${signup2Error}">
+                        회원가입 에러 메시지
                     </div>
                 </form>
             </section>


### PR DESCRIPTION
## 📌 관련 이슈
- close #181, close #183 

## ✨ 작업 내용
- [x] 회원가입 시 나타날 오류 예외처리하기
- [x] userservice에 이메일 형식 메서드 추가로 gamil.com을 확실히 받게 하기
- [x] signup1에 있는 회원가입 오류 메세지 코드 수정
- [x]  로그인 실패 횟수 누적 및 5회 이상 실패 시 계정 잠금 기능을 추가
- [x] 로그인 성공 시 실패 횟수를 초기화하고, 로그인 성공/실패 로그가 저장되도록 구현

## 변경 사항
 - user 테이블에 로그인 실패 횟수와 계정 잠금 여부 컬럼 추가
 - 로그인 실패 핸들러 / 성공 핸들러 / Security 설정 반영
 - 계정 잠금 상태일 경우 로그인 차단 처리 추가

## 📸 스크린샷 (선택 사항)
## 📚 레퍼런스 (선택 사항)
## ✅ 체크리스트
- [x] 빌드 및 실행에 문제가 없는가?
- [x] 불필요한 콘솔 로그를 제거했는가?
- [x] 기존 코드와의 충돌은 해결했는가?
