### PR TITLE
[기능 구현] 모성진 - 비밀번호 암호화

### DIFF
--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/controller/AuthController.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/controller/AuthController.java
@@ -119,20 +119,45 @@ public class AuthController {
         return "auth/findpw1";
     }
 
-    @GetMapping("/findpw2")
-    public String findPwResult(@RequestParam(required = false) String userId,
-                               @RequestParam(required = false) String phoneNumber,
-                               Model model) {
-
+    @PostMapping("/findpw2")
+    public String verifyUserForPasswordReset(@RequestParam String userId,
+                                             @RequestParam String phoneNumber,
+                                             Model model) {
         try {
-            String foundPassword = userService.findUserPassword(userId, phoneNumber);
-            model.addAttribute("foundPassword", foundPassword);
-
+            userService.validateUserForPasswordReset(userId, phoneNumber);
+            model.addAttribute("userId", userId);
+            model.addAttribute("phoneNumber", phoneNumber);
             return "auth/findpw2";
-
         } catch (IllegalArgumentException exception) {
             model.addAttribute("findPwError", exception.getMessage());
             return "auth/findpw1";
+        }
+    }
+
+    @PostMapping("/resetpw")
+    public String resetPassword(@RequestParam String userId,
+                                @RequestParam String phoneNumber,
+                                @RequestParam String newPassword,
+                                @RequestParam String confirmPassword,
+                                Model model) {
+        try {
+            if (newPassword == null || newPassword.isBlank()
+                    || confirmPassword == null || confirmPassword.isBlank()) {
+                throw new IllegalArgumentException("새 비밀번호를 모두 입력해주세요.");
+            }
+
+            if (!newPassword.equals(confirmPassword)) {
+                throw new IllegalArgumentException("새 비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+            }
+
+            userService.resetUserPassword(userId, phoneNumber, newPassword);
+            return "redirect:/auth/login";
+
+        } catch (IllegalArgumentException exception) {
+            model.addAttribute("resetPwError", exception.getMessage());
+            model.addAttribute("userId", userId);
+            model.addAttribute("phoneNumber", phoneNumber);
+            return "auth/findpw2";
         }
     }
 }

--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/controller/StudentInformationController.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/controller/StudentInformationController.java
@@ -66,8 +66,6 @@ public class StudentInformationController {
             UserInformationUpdateDTO updateDTO = new UserInformationUpdateDTO();
             updateDTO.setUserPhoneNumber(userInfo.getUserPhoneNumber());
             updateDTO.setUserEmail(userInfo.getUserEmail());
-            updateDTO.setUserPassword(userInfo.getUserPassword());
-
             model.addAttribute("userInfo", userInfo);
             model.addAttribute("updateDTO", updateDTO);
 

--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/controller/TeacherInformationController.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/controller/TeacherInformationController.java
@@ -84,7 +84,6 @@ public class TeacherInformationController {
             UserInformationUpdateDTO updateDTO = new UserInformationUpdateDTO();
             updateDTO.setUserPhoneNumber(userInfo.getUserPhoneNumber());
             updateDTO.setUserEmail(userInfo.getUserEmail());
-            updateDTO.setUserPassword(userInfo.getUserPassword());
 
             model.addAttribute("userInfo", userInfo);
             model.addAttribute("updateDTO", updateDTO);

--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/dto/UserInformationResponseDTO.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/dto/UserInformationResponseDTO.java
@@ -12,17 +12,13 @@ public class UserInformationResponseDTO {
     // 이메일
     private String userEmail;
 
-    // 비밀번호
-    private String userPassword;
-
     public UserInformationResponseDTO() {
     }
 
-    public UserInformationResponseDTO(String userName, String userPhoneNumber, String userEmail, String userPassword) {
+    public UserInformationResponseDTO(String userName, String userPhoneNumber, String userEmail) {
         this.userName = userName;
         this.userPhoneNumber = userPhoneNumber;
         this.userEmail = userEmail;
-        this.userPassword = userPassword;
     }
 
     public String getUserName() {
@@ -37,10 +33,6 @@ public class UserInformationResponseDTO {
         return userEmail;
     }
 
-    public String getUserPassword() {
-        return userPassword;
-    }
-
     public void setUserName(String userName) {
         this.userName = userName;
     }
@@ -51,9 +43,5 @@ public class UserInformationResponseDTO {
 
     public void setUserEmail(String userEmail) {
         this.userEmail = userEmail;
-    }
-
-    public void setUserPassword(String userPassword) {
-        this.userPassword = userPassword;
     }
 }

--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/entity/UserUser.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/entity/UserUser.java
@@ -188,4 +188,8 @@ public class UserUser {
     public void lockAccount() {
         this.accountLocked = true;
     }
+
+    public void updatePassword(String userPassword) {
+        this.userPassword = userPassword;
+    }
 }

--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/service/UserService.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/service/UserService.java
@@ -8,6 +8,7 @@ import com.samsamgyeesam.studyingvally.domain.user.entity.UserRole;
 import com.samsamgyeesam.studyingvally.domain.user.entity.UserUser;
 import com.samsamgyeesam.studyingvally.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,6 +24,7 @@ public class UserService {
      * user 테이블 조회용 Repository
      */
     private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
 
     /**
      * 이름 + 전화번호로 아이디 찾기
@@ -40,20 +42,30 @@ public class UserService {
         return foundUser.getUserId();
     }
 
-    /**
-     * 아이디 + 전화번호로 비밀번호 찾기
-     */
-    public String findUserPassword(String userId, String phoneNumber) {
-
+    public void validateUserForPasswordReset(String userId, String phoneNumber) {
         if (userId == null || userId.isBlank()
                 || phoneNumber == null || phoneNumber.isBlank()) {
-            throw new IllegalArgumentException("회원가입 정보를 모두 입력해주세요");
+            throw new IllegalArgumentException("아이디와 전화번호를 모두 입력해주세요.");
+        }
+
+        userRepository.findByUserIdAndUserPhoneNumber(userId, phoneNumber)
+                .orElseThrow(() -> new IllegalArgumentException("일치하는 회원 정보를 찾을 수 없습니다."));
+    }
+
+
+    @Transactional
+    public void resetUserPassword(String userId, String phoneNumber, String newPassword) {
+        if (userId == null || userId.isBlank()
+                || phoneNumber == null || phoneNumber.isBlank()
+                || newPassword == null || newPassword.isBlank()) {
+            throw new IllegalArgumentException("모든 정보를 입력해주세요.");
         }
 
         UserUser user = userRepository.findByUserIdAndUserPhoneNumber(userId, phoneNumber)
                 .orElseThrow(() -> new IllegalArgumentException("일치하는 회원 정보를 찾을 수 없습니다."));
 
-        return user.getUserPassword();
+        String encodedPassword = passwordEncoder.encode(newPassword);
+        user.updatePassword(encodedPassword);
     }
 
     /**
@@ -117,11 +129,13 @@ public class UserService {
             throw new IllegalArgumentException("회원가입 유형을 선택해주세요.");
         }
 
+        String encodedPassword = passwordEncoder.encode(signupDTO.getUserPassword());
+
         /* DTO -> Entity 변환 */
         UserUser newUser = UserUser.builder()
                 .userName(signupDTO.getUserName())
                 .userId(signupDTO.getUserId())
-                .userPassword(signupDTO.getUserPassword())
+                .userPassword(encodedPassword)
                 .userPhoneNumber(signupDTO.getUserPhoneNumber())
                 .userEmail(signupDTO.getUserEmail())
                 .userNickname(signupDTO.getUserNickname())
@@ -145,8 +159,7 @@ public class UserService {
         return new UserInformationResponseDTO(
                 user.getUserName(),
                 user.getUserPhoneNumber(),
-                user.getUserEmail(),
-                user.getUserPassword()
+                user.getUserEmail()
         );
     }
 
@@ -155,6 +168,8 @@ public class UserService {
      */
     @Transactional
     public void updateUserInformation(String loginUserId, UserInformationUpdateDTO updateDTO) {
+
+        String encodedPassword = passwordEncoder.encode(updateDTO.getUserPassword());
 
         UserUser user = userRepository.findByUserId(loginUserId)
                 .orElseThrow(() -> new IllegalArgumentException("회원 정보를 찾을 수 없습니다."));
@@ -173,7 +188,7 @@ public class UserService {
         user.updateInformation(
                 updateDTO.getUserPhoneNumber(),
                 updateDTO.getUserEmail(),
-                updateDTO.getUserPassword()
+                encodedPassword
         );
     }
 
@@ -190,7 +205,7 @@ public class UserService {
             throw new IllegalArgumentException("비밀번호를 입력해주세요.");
         }
 
-        if (!user.getUserPassword().equals(deleteUserDTO.getUserPassword())) {
+        if (!passwordEncoder.matches(deleteUserDTO.getUserPassword(), user.getUserPassword())) {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
 
@@ -209,7 +224,7 @@ public class UserService {
             throw new IllegalArgumentException("비밀번호를 입력해주세요.");
         }
 
-        if (!user.getUserPassword().equals(userPassword)) {
+        if (!passwordEncoder.matches(userPassword, user.getUserPassword())) {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
     }

--- a/src/main/java/com/samsamgyeesam/studyingvally/global/Config/PasswordConfig.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/global/Config/PasswordConfig.java
@@ -1,0 +1,15 @@
+package com.samsamgyeesam.studyingvally.global.Config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class PasswordConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/samsamgyeesam/studyingvally/global/Config/SecurityConfig.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/global/Config/SecurityConfig.java
@@ -10,8 +10,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
-import org.springframework.security.crypto.password.NoOpPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
@@ -33,10 +31,6 @@ public class SecurityConfig {
         return web -> web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations());
     }
 
-    @Bean
-    public PasswordEncoder passwordEncoder() {
-        return NoOpPasswordEncoder.getInstance();
-    }
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http

--- a/src/main/resources/templates/auth/findpw1.html
+++ b/src/main/resources/templates/auth/findpw1.html
@@ -1,21 +1,13 @@
 <!DOCTYPE html>
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
-    <!-- 문자 인코딩 -->
     <meta charset="UTF-8" />
-
-    <!-- 반응형 설정 -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-
-    <!-- 브라우저 탭 제목 -->
     <title>강의 마을 - 비밀번호 찾기</title>
-
-    <!-- auth 화면 공통 CSS -->
     <link rel="stylesheet" th:href="@{/css/auth.css}">
 </head>
 <body>
 <div class="game-screen">
-    <!-- 배경 요소 -->
     <div class="sun"></div>
     <div class="cloud c1"></div>
     <div class="cloud c2"></div>
@@ -38,20 +30,17 @@
 
     <div class="panel-wrap">
         <div class="panel">
-
-            <!-- 비밀번호 찾기 화면 -->
             <section id="findPwScreen" class="form-screen active">
                 <h1 class="title">비밀번호 찾기</h1>
 
-                <form class="form-box" th:action="@{/auth/findpw2}" method="get">
-
+                <form class="form-box" th:action="@{/auth/findpw2}" method="post">
                     <div class="field">
                         <label for="userId">아이디</label>
                         <input type="text"
                                id="userId"
                                name="userId"
                                placeholder="아이디 입력"
-                               required />
+                               required>
                     </div>
 
                     <div class="field">
@@ -60,32 +49,32 @@
                                id="phoneNumber"
                                name="phoneNumber"
                                placeholder="전화번호 입력"
-                               required />
+                               required>
                     </div>
 
                     <div class="bottom-row">
-                        <!-- 첫 화면으로 이동 -->
                         <button type="button"
-                                onclick="location.href='/main'"
+                                onclick="location.href='/auth/find'"
                                 class="pixel-btn secondary"
                                 id="backFromFindPwBtn">
                             뒤로가기
                         </button>
 
-                        <!-- 비밀번호 찾기 결과 화면으로 이동 -->
                         <button type="submit"
                                 class="pixel-btn"
                                 id="findPwSubmitBtn">
-                            비밀번호 찾기
+                            본인 확인
                         </button>
                     </div>
 
-                    <div id="findPwMsg" class="msg show error" th:if="${findPwError}">
-                        <span th:text="${findPwError}">일치하는 회원 정보를 찾을 수 없습니다.</span>
+                    <div class="msg show error"
+                         th:if="${findPwError != null}">
+                        <span th:text="${findPwError}">
+                            일치하는 회원 정보를 찾을 수 없습니다.
+                        </span>
                     </div>
                 </form>
             </section>
-
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/auth/findpw2.html
+++ b/src/main/resources/templates/auth/findpw2.html
@@ -1,21 +1,13 @@
 <!DOCTYPE html>
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
-    <!-- 문자 인코딩 -->
     <meta charset="UTF-8" />
-
-    <!-- 반응형 설정 -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-
-    <!-- 브라우저 탭 제목 -->
-    <title>강의 마을 - 비밀번호 찾기 결과</title>
-
-    <!-- auth 공통 CSS 사용 -->
+    <title>강의 마을 - 비밀번호 재설정</title>
     <link rel="stylesheet" th:href="@{/css/auth.css}">
 </head>
 <body>
 <div class="game-screen">
-    <!-- 배경 요소 -->
     <div class="sun"></div>
     <div class="cloud c1"></div>
     <div class="cloud c2"></div>
@@ -38,31 +30,54 @@
 
     <div class="panel-wrap">
         <div class="panel">
+            <section id="resetPwScreen" class="form-screen active">
+                <h1 class="title">비밀번호 재설정</h1>
 
-            <!-- 비밀번호 찾기 결과 화면 -->
-            <section id="findPwResultScreen" class="form-screen active">
-                <h1 class="title">비밀번호 찾기 결과</h1>
+                <form class="form-box" th:action="@{/auth/resetpw}" method="post">
+                    <input type="hidden" name="userId" th:value="${userId}">
+                    <input type="hidden" name="phoneNumber" th:value="${phoneNumber}">
 
-                <div class="form-box result-box">
-                    <p class="result-text">비밀번호는</p>
+                    <div class="field">
+                        <label for="newPassword">새 비밀번호</label>
+                        <input type="password"
+                               id="newPassword"
+                               name="newPassword"
+                               placeholder="새 비밀번호 입력"
+                               required>
+                    </div>
 
-                    <!-- 찾은 비밀번호 출력 -->
-                    <p class="result-value" th:text="${foundPassword}">1234!</p>
+                    <div class="field">
+                        <label for="confirmPassword">새 비밀번호 확인</label>
+                        <input type="password"
+                               id="confirmPassword"
+                               name="confirmPassword"
+                               placeholder="비밀번호를 다시 입력"
+                               required>
+                    </div>
 
-                    <p class="result-text">입니다</p>
-
-                    <div class="bottom-row single-row">
-                        <!-- 확인 버튼 클릭 시 첫 화면으로 이동 -->
+                    <div class="bottom-row">
                         <button type="button"
-                                onclick="location.href='/main'"
+                                onclick="history.back()"
+                                class="pixel-btn secondary"
+                                id="backFromResetPwBtn">
+                            뒤로가기
+                        </button>
+
+                        <button type="submit"
                                 class="pixel-btn"
-                                id="confirmFindPwBtn">
-                            확인
+                                id="resetPwSubmitBtn">
+                            비밀번호 재설정
                         </button>
                     </div>
-                </div>
-            </section>
 
+                    <div class="msg show error"
+                         th:if="${resetPwError != null}">
+                        <span th:text="${resetPwError}">
+                            비밀번호 재설정 중 오류가 발생했습니다.
+                        </span>
+                    </div>
+                </form>
+            </section>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/auth/showinformation.html
+++ b/src/main/resources/templates/auth/showinformation.html
@@ -70,9 +70,6 @@
 <!-- 비밀번호 -->
 <div>
     <label>비밀번호</label>
-    <input type="password"
-           th:value="${userInfo != null ? userInfo.userPassword : ''}"
-           readonly>
 </div>
 
 <!-- 수정 버튼 -->

--- a/src/main/resources/templates/auth/updateinformation.html
+++ b/src/main/resources/templates/auth/updateinformation.html
@@ -38,12 +38,11 @@
     </div>
 
     <div>
-        <label for="userPassword">비밀번호</label>
+        <label for="userPassword">새 비밀번호</label>
         <input type="password"
                id="userPassword"
                name="userPassword"
-               th:value="${updateDTO != null ? updateDTO.userPassword : ''}"
-               required>
+               placeholder="새 비밀번호를 입력하세요">
     </div>
 
     <div>


### PR DESCRIPTION
## 📌 관련 이슈
- close #195 

## ✨ 작업 내용
- [] 비밀번호 보안 처리 방식으로 전환했습니다. 기존 평문 저장/비교 구조를 BCryptPasswordEncoder 기반 해시 저장으로 바꾸고, 회원가입 회원정보 수정 시 비밀번호를 인코딩해서 저장하도록 변경했습니다.
- [] 본인 확인과 회원 탈퇴 시에는 평문 equals() 비교 대신 passwordEncoder.matches()를 사용하도록 수정했습니다.
- [] 회원정보 조회 DTO/화면에서 비밀번호 노출을 없앴고, 기존 “비밀번호 찾기” 기능은 아이디/전화번호 본인 확인 후 새 비밀번호를 입력하는 “비밀번호 재설정” 흐름으로 변경했습니다. 
- [] PasswordEncoder 빈을 별도 설정으로 분리해 Spring Security 순환 참조도 함께 정리했습니다.

## 📸 스크린샷 (선택 사항)
## 📚 레퍼런스 (선택 사항)
## ✅ 체크리스트
- [ ] 빌드 및 실행에 문제가 없는가?
- [ ] 불필요한 콘솔 로그를 제거했는가?
- [ ] 기존 코드와의 충돌은 해결했는가?
