### PR TITLE
[기능 구현][BUG] 모성진 - 관리자가 사용자 상태 변경, Bcrypt 추가 후 로그인이 안되는 오류 발생 해결

### DIFF
--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/entity/UserUser.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/entity/UserUser.java
@@ -28,11 +28,8 @@ public class UserUser {
     @Column(name = "user_id", nullable = false, unique = true)
     private String userId;
 
-    /**
+    /*
      * 비밀번호
-     *
-     * 현재는 평문 상태 그대로 사용
-     * 나중에 BCrypt로 변경 예정
      */
     @Column(name = "user_password", nullable = false)
     private String userPassword;
@@ -189,7 +186,13 @@ public class UserUser {
         this.accountLocked = true;
     }
 
+    // 재설정 업데이트
     public void updatePassword(String userPassword) {
         this.userPassword = userPassword;
+    }
+
+    // 상태 확인 메서드
+    public boolean isActive() {
+        return "ACTIVE".equalsIgnoreCase(this.userStatus);
     }
 }

--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/service/AuthFailHandler.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/service/AuthFailHandler.java
@@ -7,6 +7,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.authentication.LockedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
@@ -77,7 +78,10 @@ public class AuthFailHandler extends SimpleUrlAuthenticationFailureHandler {
             /*
              * 그 외 예외
              */
-        } else {
+        } else if (exception instanceof DisabledException) {
+        errorMessage = "비활성화된 계정입니다. 관리자에게 문의해주세요.";
+
+        }else {
             errorMessage = "로그인 요청을 처리할 수 없습니다.";
         }
 

--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/service/AuthUserDetails.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/service/AuthUserDetails.java
@@ -48,6 +48,9 @@ public class AuthUserDetails implements UserDetails {
      */
     private final boolean accountLocked;
 
+    // 계정 상태
+    private final boolean enabled;
+
     /**
      * 일반 사용자 생성자
      */
@@ -58,6 +61,7 @@ public class AuthUserDetails implements UserDetails {
         this.displayName = user.getUserNickname();
         this.userNo = user.getUserNo();
         this.accountLocked = user.isAccountLocked();
+        this.enabled = user.isActive();
     }
 
     /**
@@ -70,6 +74,7 @@ public class AuthUserDetails implements UserDetails {
         this.displayName = "관리자";
         this.userNo = null;
         this.accountLocked = false;
+        this.enabled = true;
     }
 
     /**
@@ -129,6 +134,8 @@ public class AuthUserDetails implements UserDetails {
      */
     @Override
     public boolean isEnabled() {
-        return true;
+        return enabled;
     }
+
+
 }

--- a/src/test/java/com/samsamgyeesam/studyingvally/PasswordHashGenerator.java
+++ b/src/test/java/com/samsamgyeesam/studyingvally/PasswordHashGenerator.java
@@ -1,0 +1,13 @@
+package com.samsamgyeesam.studyingvally;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+public class PasswordHashGenerator {
+    public static void main(String[] args) {
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+
+        System.out.println("pw123 -> " + encoder.encode("pw123"));
+        System.out.println("admin123! -> " + encoder.encode("admin123!"));
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
- #198 , #201 

## ✨ 작업 내용
- [ ] 관리자가 상태 변경 할 수 있도록 상태 확인 메서드 추가
- [ ] BCrypt 추가 후 기존에 있던 정보는 비밀번호가 암호화 되지 않은 상황
- [ ] 사용자는 pw123으로 통일, 관리자는 admin123!으로 암호화로 변경 후 DB에 적용

## 📸 스크린샷 (선택 사항)
## 📚 레퍼런스 (선택 사항)
## ✅ 체크리스트
- [ ] 빌드 및 실행에 문제가 없는가?
- [ ] 불필요한 콘솔 로그를 제거했는가?
- [ ] 기존 코드와의 충돌은 해결했는가?
