### PR TITLE
[기능 구현] 모성진 - 내 정보 수정 오류 해결, 다른 역할 페이지 이동 시 오류 페이지 생성

### DIFF
--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/controller/AuthController.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/controller/AuthController.java
@@ -4,6 +4,7 @@ import com.samsamgyeesam.studyingvally.domain.user.dto.SignupDTO;
 import com.samsamgyeesam.studyingvally.domain.user.service.UserService;
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,15 +13,44 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+/**
+ * 인증/회원가입/아이디 찾기/비밀번호 재설정 관련 요청을 처리하는 컨트롤러
+ *
+ * 추가된 핵심 로직:
+ * - 이미 로그인한 사용자가 /auth 하위 공개 페이지로 다시 접근하면
+ *   역할에 맞는 메인 페이지로 강제 이동시킨다.
+ * - 학생  -> /student/main
+ * - 강사  -> /teacher/teachermain
+ * - 관리자 -> /admin/main
+ */
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("/auth")
 public class AuthController {
 
+    /**
+     * 회원 관련 비즈니스 로직 서비스
+     */
     private final UserService userService;
 
+    /**
+     * 로그인 화면
+     *
+     * 이미 로그인한 상태면 로그인 화면을 다시 보여주지 않고
+     * 역할별 메인 화면으로 보낸다.
+     */
     @GetMapping("/login")
-    public String login(Model model, HttpSession session) {
+    public String login(Authentication authentication, Model model, HttpSession session) {
+
+        String redirectUrl = getRedirectUrlByRole(authentication);
+        if (redirectUrl != null) {
+            return "redirect:" + redirectUrl;
+        }
+
+        /*
+         * 로그인 실패 메시지는 AuthFailHandler가 session에 저장해둔 값을 꺼내서 사용한다.
+         * 한 번 보여준 뒤에는 제거한다.
+         */
         String loginErrorMessage = (String) session.getAttribute("loginErrorMessage");
 
         if (loginErrorMessage != null && !loginErrorMessage.isBlank()) {
@@ -32,28 +62,67 @@ public class AuthController {
         return "auth/login";
     }
 
+    /**
+     * 로그인 에러 재진입용 URL
+     *
+     * 실제 처리는 login()과 동일하게 맞춘다.
+     */
     @GetMapping("/loginerror")
-    public String loginError(Model model, HttpSession session) {
-        return login(model, session);
+    public String loginError(Authentication authentication, Model model, HttpSession session) {
+        return login(authentication, model, session);
     }
 
+    /**
+     * 회원가입 유형 선택 화면
+     *
+     * 이미 로그인했으면 접근 차단 후 역할별 메인으로 이동
+     */
     @GetMapping("/signuptype")
-    public String signupType() {
+    public String signupType(Authentication authentication) {
+
+        String redirectUrl = getRedirectUrlByRole(authentication);
+        if (redirectUrl != null) {
+            return "redirect:" + redirectUrl;
+        }
+
         return "auth/signuptype";
     }
 
+    /**
+     * 회원가입 1단계 화면
+     *
+     * userRole(STUDENT / TEACHER)을 받아서 화면에 전달
+     * 이미 로그인했으면 접근 차단
+     */
     @GetMapping("/signup1")
-    public String signup1(@RequestParam(required = false) String userRole,
+    public String signup1(Authentication authentication,
+                          @RequestParam(required = false) String userRole,
                           Model model) {
 
-        model.addAttribute("userRole", userRole);
+        String redirectUrl = getRedirectUrlByRole(authentication);
+        if (redirectUrl != null) {
+            return "redirect:" + redirectUrl;
+        }
 
+        model.addAttribute("userRole", userRole);
         return "auth/signup1";
     }
 
+    /**
+     * 회원가입 2단계 화면으로 이동하기 전 1차 입력값 검증
+     *
+     * 주의:
+     * 이 단계는 최종 저장이 아니라 화면 이동 전 검증이다.
+     */
     @PostMapping("/signup2")
-    public String signup2(@ModelAttribute SignupDTO signupDTO,
+    public String signup2(Authentication authentication,
+                          @ModelAttribute SignupDTO signupDTO,
                           Model model) {
+
+        String redirectUrl = getRedirectUrlByRole(authentication);
+        if (redirectUrl != null) {
+            return "redirect:" + redirectUrl;
+        }
 
         if (signupDTO.getUserName() == null || signupDTO.getUserName().isBlank()
                 || signupDTO.getUserId() == null || signupDTO.getUserId().isBlank()
@@ -61,20 +130,29 @@ public class AuthController {
                 || signupDTO.getUserPhoneNumber() == null || signupDTO.getUserPhoneNumber().isBlank()
                 || signupDTO.getUserEmail() == null || signupDTO.getUserEmail().isBlank()) {
 
-            model.addAttribute("signup1Error", "?뚯썝媛???뺣낫瑜?紐⑤몢 ?낅젰?댁＜?몄슂.");
+            model.addAttribute("signup1Error", "회원가입 정보를 모두 입력해주세요.");
             model.addAttribute("signupDTO", signupDTO);
-
             return "auth/signup1";
         }
 
         model.addAttribute("signupDTO", signupDTO);
-
         return "auth/signup2";
     }
 
+    /**
+     * 최종 회원가입 처리
+     *
+     * 이미 로그인 상태면 회원가입 페이지 접근 자체를 막는다.
+     */
     @PostMapping("/signup")
-    public String signup(@ModelAttribute SignupDTO signupDTO,
+    public String signup(Authentication authentication,
+                         @ModelAttribute SignupDTO signupDTO,
                          Model model) {
+
+        String redirectUrl = getRedirectUrlByRole(authentication);
+        if (redirectUrl != null) {
+            return "redirect:" + redirectUrl;
+        }
 
         try {
             userService.signup(signupDTO);
@@ -87,25 +165,53 @@ public class AuthController {
         }
     }
 
+    /**
+     * 아이디/비밀번호 찾기 선택 화면
+     */
     @GetMapping("/find")
-    public String find() {
+    public String find(Authentication authentication) {
+
+        String redirectUrl = getRedirectUrlByRole(authentication);
+        if (redirectUrl != null) {
+            return "redirect:" + redirectUrl;
+        }
+
         return "auth/find";
     }
 
+    /**
+     * 아이디 찾기 화면
+     */
     @GetMapping("/findid")
-    public String findId() {
+    public String findId(Authentication authentication) {
+
+        String redirectUrl = getRedirectUrlByRole(authentication);
+        if (redirectUrl != null) {
+            return "redirect:" + redirectUrl;
+        }
+
         return "auth/findid";
     }
 
+    /**
+     * 아이디 찾기 결과 처리
+     *
+     * 이름 + 전화번호로 사용자 아이디를 조회한다.
+     */
     @GetMapping("/findid2")
-    public String findIdResult(@RequestParam(required = false) String userName,
+    public String findIdResult(Authentication authentication,
+                               @RequestParam(required = false) String userName,
                                @RequestParam(required = false) String phoneNumber,
                                Model model) {
+
+        String redirectUrl = getRedirectUrlByRole(authentication);
+        if (redirectUrl != null) {
+            return "redirect:" + redirectUrl;
+        }
 
         try {
             String foundUserId = userService.findUserId(userName, phoneNumber);
             model.addAttribute("foundUserId", foundUserId);
-
             return "auth/findid2";
 
         } catch (IllegalArgumentException exception) {
@@ -114,32 +220,71 @@ public class AuthController {
         }
     }
 
+    /**
+     * 비밀번호 재설정 1단계 화면
+     *
+     * 아이디 + 전화번호 본인 확인 입력 화면
+     */
     @GetMapping("/findpw1")
-    public String findPw() {
+    public String findPw(Authentication authentication) {
+
+        String redirectUrl = getRedirectUrlByRole(authentication);
+        if (redirectUrl != null) {
+            return "redirect:" + redirectUrl;
+        }
+
         return "auth/findpw1";
     }
 
+    /**
+     * 비밀번호 재설정 2단계 진입 전 본인 확인
+     *
+     * userId + phoneNumber 조합이 맞는 사용자만
+     * 실제 비밀번호 재설정 화면(findpw2)으로 이동시킨다.
+     */
     @PostMapping("/findpw2")
-    public String verifyUserForPasswordReset(@RequestParam String userId,
+    public String verifyUserForPasswordReset(Authentication authentication,
+                                             @RequestParam String userId,
                                              @RequestParam String phoneNumber,
                                              Model model) {
+
+        String redirectUrl = getRedirectUrlByRole(authentication);
+        if (redirectUrl != null) {
+            return "redirect:" + redirectUrl;
+        }
+
         try {
             userService.validateUserForPasswordReset(userId, phoneNumber);
             model.addAttribute("userId", userId);
             model.addAttribute("phoneNumber", phoneNumber);
             return "auth/findpw2";
+
         } catch (IllegalArgumentException exception) {
             model.addAttribute("findPwError", exception.getMessage());
             return "auth/findpw1";
         }
     }
 
+    /**
+     * 새 비밀번호 저장 처리
+     *
+     * 1. 새 비밀번호 입력 여부 확인
+     * 2. 새 비밀번호 / 확인 비밀번호 일치 여부 확인
+     * 3. 서비스에서 BCrypt 해시로 저장
+     */
     @PostMapping("/resetpw")
-    public String resetPassword(@RequestParam String userId,
+    public String resetPassword(Authentication authentication,
+                                @RequestParam String userId,
                                 @RequestParam String phoneNumber,
                                 @RequestParam String newPassword,
                                 @RequestParam String confirmPassword,
                                 Model model) {
+
+        String redirectUrl = getRedirectUrlByRole(authentication);
+        if (redirectUrl != null) {
+            return "redirect:" + redirectUrl;
+        }
+
         try {
             if (newPassword == null || newPassword.isBlank()
                     || confirmPassword == null || confirmPassword.isBlank()) {
@@ -159,5 +304,57 @@ public class AuthController {
             model.addAttribute("phoneNumber", phoneNumber);
             return "auth/findpw2";
         }
+    }
+
+    /**
+     * 현재 인증 정보(authentication)를 보고
+     * 로그인 상태면 역할별 메인 페이지 URL을 반환한다.
+     *
+     * 반환값:
+     * - 학생   -> /student/main
+     * - 강사   -> /teacher/teachermain
+     * - 관리자 -> /admin/main
+     * - 비로그인 -> null
+     */
+    private String getRedirectUrlByRole(Authentication authentication) {
+
+        /*
+         * 아래 경우는 로그인 상태가 아니라고 본다.
+         * 1. authentication 자체가 없음
+         * 2. 인증 완료 상태가 아님
+         * 3. anonymousUser(익명 사용자)
+         */
+        if (authentication == null
+                || !authentication.isAuthenticated()
+                || "anonymousUser".equals(authentication.getName())) {
+            return null;
+        }
+
+        if (hasRole(authentication, "ROLE_STUDENT")) {
+            return "/student/main";
+        }
+
+        if (hasRole(authentication, "ROLE_TEACHER")) {
+            return "/teacher/teachermain";
+        }
+
+        if (hasRole(authentication, "ROLE_ADMIN")) {
+            return "/admin/main";
+        }
+
+        return null;
+    }
+
+    /**
+     * 현재 인증 정보가 특정 권한을 가지고 있는지 확인하는 공통 메서드
+     *
+     * 예:
+     * - ROLE_STUDENT
+     * - ROLE_TEACHER
+     * - ROLE_ADMIN
+     */
+    private boolean hasRole(Authentication authentication, String role) {
+        return authentication.getAuthorities().stream()
+                .anyMatch(authority -> authority.getAuthority().equals(role));
     }
 }

--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/controller/ErrorPageController.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/controller/ErrorPageController.java
@@ -1,0 +1,13 @@
+package com.samsamgyeesam.studyingvally.domain.user.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class ErrorPageController {
+
+    @GetMapping("/error-page")
+    public String errorPage() {
+        return "error/error";
+    }
+}

--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/entity/UserUser.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/entity/UserUser.java
@@ -110,7 +110,11 @@ public class UserUser {
 
 
     // 내 정보 수정
-    public void updateInformation(String userNickname, String userPhoneNumber, String userEmail, String userPassword, String userGender) {
+    public void updateInformation(String userNickname,
+                                  String userPhoneNumber,
+                                  String userEmail,
+                                  String userGender,
+                                  String userPassword) {
         this.userNickname = userNickname;
         this.userPhoneNumber = userPhoneNumber;
         this.userEmail = userEmail;

--- a/src/main/java/com/samsamgyeesam/studyingvally/domain/user/service/UserService.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/domain/user/service/UserService.java
@@ -14,6 +14,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.concurrent.atomic.AtomicReference;
+
 //사용자 관련 비즈니스 로직 서비스
 @Service
 @RequiredArgsConstructor
@@ -157,24 +159,55 @@ public class UserService {
         );
     }
 
-    // 현재 로그인한 사용자 정보 수정
+//    // 현재 로그인한 사용자 정보 수정
+//    @Transactional
+//    public void updateUserInformation(String loginUserId, UserInformationUpdateDTO updateDTO) {
+//
+//        String encodedPassword = passwordEncoder.encode(updateDTO.getUserPassword());
+//
+//        UserUser user = userRepository.findByUserId(loginUserId)
+//                .orElseThrow(() -> new IllegalArgumentException("회원 정보를 찾을 수 없습니다."));
+//
+//        if (updateDTO.getUserPhoneNumber() == null || updateDTO.getUserPhoneNumber().isBlank()
+//                || updateDTO.getUserEmail() == null || updateDTO.getUserEmail().isBlank()
+//                || updateDTO.getUserPassword() == null || updateDTO.getUserPassword().isBlank()
+//                || updateDTO.getUserNickname() == null || updateDTO.getUserNickname().isBlank()
+//                || updateDTO.getUserGender() == null || updateDTO.getUserGender().isBlank()) {
+//            throw new IllegalArgumentException("수정할 정보를 모두 입력해주세요.");
+//        }
+//
+//        // 이메일 형식 검증
+//        if (!isValidEmailFormat(updateDTO.getUserEmail())) {
+//            throw new IllegalArgumentException("gmail 형식의 이메일만 입력 가능합니다.");
+//        }
+//
+//        if (!user.getUserNickname().equals(updateDTO.getUserNickname())
+//                && userRepository.existsByUserNickname(updateDTO.getUserNickname())) {
+//            throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
+//        }
+//
+//        user.updateInformation(
+//                updateDTO.getUserNickname(),
+//                updateDTO.getUserPhoneNumber(),
+//                updateDTO.getUserEmail(),
+//                updateDTO.getUserGender(),
+//                encodedPassword
+//        );
+//    }
+
     @Transactional
     public void updateUserInformation(String loginUserId, UserInformationUpdateDTO updateDTO) {
-
-        String encodedPassword = passwordEncoder.encode(updateDTO.getUserPassword());
 
         UserUser user = userRepository.findByUserId(loginUserId)
                 .orElseThrow(() -> new IllegalArgumentException("회원 정보를 찾을 수 없습니다."));
 
-        if (updateDTO.getUserPhoneNumber() == null || updateDTO.getUserPhoneNumber().isBlank()
+        if (updateDTO.getUserNickname() == null || updateDTO.getUserNickname().isBlank()
+                || updateDTO.getUserPhoneNumber() == null || updateDTO.getUserPhoneNumber().isBlank()
                 || updateDTO.getUserEmail() == null || updateDTO.getUserEmail().isBlank()
-                || updateDTO.getUserPassword() == null || updateDTO.getUserPassword().isBlank()
-                || updateDTO.getUserNickname() == null || updateDTO.getUserNickname().isBlank()
                 || updateDTO.getUserGender() == null || updateDTO.getUserGender().isBlank()) {
             throw new IllegalArgumentException("수정할 정보를 모두 입력해주세요.");
         }
 
-        // 이메일 형식 검증
         if (!isValidEmailFormat(updateDTO.getUserEmail())) {
             throw new IllegalArgumentException("gmail 형식의 이메일만 입력 가능합니다.");
         }
@@ -184,12 +217,19 @@ public class UserService {
             throw new IllegalArgumentException("이미 사용 중인 닉네임입니다.");
         }
 
+        AtomicReference<String> passwordToSave = new AtomicReference<>(user.getUserPassword());
+
+        // 새 비밀번호를 입력한 경우에만 변경
+        if (updateDTO.getUserPassword() != null && !updateDTO.getUserPassword().isBlank()) {
+            passwordToSave.set(passwordEncoder.encode(updateDTO.getUserPassword()));
+        }
+
         user.updateInformation(
                 updateDTO.getUserNickname(),
                 updateDTO.getUserPhoneNumber(),
                 updateDTO.getUserEmail(),
                 updateDTO.getUserGender(),
-                encodedPassword
+                passwordToSave.get()
         );
     }
 
@@ -208,6 +248,10 @@ public class UserService {
             throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
         }
 
+        // 1. 상태 테이블 먼저 삭제
+        userAccountStateRepository.deleteById(user.getUserNo());
+
+        // 2. 그 다음 user 삭제
         userRepository.delete(user);
     }
 

--- a/src/main/java/com/samsamgyeesam/studyingvally/global/Config/SecurityConfig.java
+++ b/src/main/java/com/samsamgyeesam/studyingvally/global/Config/SecurityConfig.java
@@ -17,16 +17,16 @@ import org.springframework.security.web.SecurityFilterChain;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    //로그인 시 사용자 인증 정보를 조회하는 서비스
+    // 로그인 시 사용자 정보를 조회하는 서비스
     private final AuthUserDetailsService authUserDetailsService;
 
-    //로그인 성공 후 권한별 이동 경로를 분기하는 핸들러
+    // 로그인 성공 시 역할별 메인 페이지로 보내는 핸들러
     private final AuthSuccessHandler authSuccessHandler;
 
-    // 로그인 실패 시 처리 클래스를 스프링이 주입해서 쓰기 위한 필드
+    // 로그인 실패 시 에러 메시지 처리 핸들러
     private final AuthFailHandler authFailHandler;
 
-    // 정적 리소스 예외 처리 (js, css, images 등)
+    // css, js, image 같은 정적 리소스는 시큐리티 검사 제외
     @Bean
     public WebSecurityCustomizer webSecurityCustomizer() {
         return web -> web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations());
@@ -35,19 +35,39 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                // 개발 단계 기준 csrf 비활성화
                 .csrf(csrf -> csrf.disable())
+
+                // URL 접근 권한 설정
                 .authorizeHttpRequests(auth -> auth
+                        // 비로그인도 접근 가능한 공개 페이지
                         .requestMatchers(
                                 "/",
                                 "/main",
                                 "/auth/**",
                                 "/image/**"
-                                // 이미지를 넣은 이유는 정적 리스소 경로 처리하는데 images는 처리하지만 image는 예외처리에서 빠질 수 있다함
-                                // 그래서 js, css는 뺐지만 image만 따로 넣어줌
                         ).permitAll()
+
+                        // 학생 전용 경로
+                        .requestMatchers("/student/**").hasRole("STUDENT")
+
+                        // 강사 전용 경로
+                        // 강사 관련 URL이 /teacher/**로 통일되어 있지 않아서
+                        // 루트 경로도 함께 묶어준다.
+                        .requestMatchers(
+                                "/teacher/**",
+                                "/showinformation",
+                                "/updateinformation",
+                                "/deleteaccount",
+                                "/showinformation/check-password"
+                        ).hasRole("TEACHER")
+
+                        // 관리자 전용 경로
+                        .requestMatchers("/admin/**").hasRole("ADMIN")
+
+                        // 그 외 요청은 로그인 필요
                         .anyRequest().authenticated()
                 )
-
 
                 // 로그인 설정
                 .formLogin(login -> login
@@ -67,9 +87,16 @@ public class SecurityConfig {
                         .invalidateHttpSession(true)
                         .clearAuthentication(true)
                         .permitAll()
-                );
+                )
+
+                // 잘못된 페이지 경로로 갔을 때 오류
+                .exceptionHandling(exception -> exception
+                .accessDeniedPage("/error-page")
+        )
+
+                // UserDetailsService 명시 연결
+                .userDetailsService(authUserDetailsService);
 
         return http.build();
     }
-
 }

--- a/src/main/resources/templates/auth/updateinformation.html
+++ b/src/main/resources/templates/auth/updateinformation.html
@@ -74,7 +74,7 @@
         <input type="password"
                id="userPassword"
                name="userPassword"
-               placeholder="새 비밀번호를 입력하세요">
+               placeholder="변경할 때만 입력하세요">
     </div>
 
     <div>

--- a/src/main/resources/templates/error/error.html
+++ b/src/main/resources/templates/error/error.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>오류</title>
+    <link rel="stylesheet" th:href="@{/css/auth.css}">
+</head>
+<body>
+<div class="game-screen">
+    <div class="sun"></div>
+    <div class="cloud c1"></div>
+    <div class="cloud c2"></div>
+    <div class="cloud c3"></div>
+
+    <div class="mountains"></div>
+    <div class="far-trees"></div>
+
+    <div class="ground"></div>
+    <div class="path"></div>
+    <div class="fence"></div>
+
+    <div class="house">
+        <div class="roof"></div>
+        <div class="body"></div>
+        <div class="window left"></div>
+        <div class="window right"></div>
+        <div class="door"></div>
+    </div>
+
+    <div class="panel-wrap">
+        <div class="panel">
+            <section class="form-screen active">
+                <h1 class="title">잘못된 경로입니다.</h1>
+                <p class="subtitle">
+                    요청한 페이지에 접근할 수 없거나 존재하지 않는 페이지입니다.
+                </p>
+
+                <div class="bottom-row">
+                    <button type="button"
+                            class="pixel-btn secondary"
+                            onclick="history.back()">
+                        뒤로가기
+                    </button>
+
+                    <button type="button"
+                            class="pixel-btn"
+                            onclick="location.href='/main'">
+                        메인으로
+                    </button>
+                </div>
+            </section>
+        </div>
+    </div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## 📌 관련 이슈
- #230 

## ✨ 작업 내용
- [] 학생/강사/관리자 역할별 접근 제어를 강화했습니다.
- []  로그인 상태 사용자가 /main, 로그인, 회원가입, 계정 찾기 페이지에 재접근하면 로그아웃 전까지 각 역할의 메인 페이지로 리다이렉트되도록 인증 컨트롤러를 보완했고, 역할별 URL 접근 제한을 적용해 다른 역할 전용 경로 접근 시 차단되도록 정리했습니다.
- [] 추가로 계정 상태 분리 구조에 맞춰 탈퇴 시 user_account_state와 user 삭제 순서를 고려해야 하는 문제를 확인했고, 내 정보 수정에서는 성별 수정 가능, 비밀번호는 입력 시에만 변경되고 비워두면 기존 값이 유지되도록 업데이트 로직을 정리했습니다.

## 📸 스크린샷 (선택 사항)
## 📚 레퍼런스 (선택 사항)
## ✅ 체크리스트
- [ ] 빌드 및 실행에 문제가 없는가?
- [ ] 불필요한 콘솔 로그를 제거했는가?
- [ ] 기존 코드와의 충돌은 해결했는가?
